### PR TITLE
feat: add crawlable pagination to the blog list

### DIFF
--- a/src/app/[locale]/_components/Pager/index.tsx
+++ b/src/app/[locale]/_components/Pager/index.tsx
@@ -1,0 +1,91 @@
+import { Link } from "@/i18n/navigation";
+import styles from "./style.module.css";
+
+export type PagerProps = {
+  /** 1ページ目の URL。2ページ目以降は末尾に /page/N を足す。 */
+  basePath: string;
+  current: number;
+  total: number;
+};
+
+/** 現在地の前後と両端だけを残し、間を省略記号に畳む。
+    25ページあっても並びが横に溢れないようにするため。 */
+function visiblePages(current: number, total: number): (null | number)[] {
+  const kept = new Set([1, total, current - 1, current, current + 1]);
+  const pages = [...kept]
+    .filter((page) => page >= 1 && page <= total)
+    .sort((a, b) => a - b);
+
+  return pages.flatMap((page, index) => {
+    const previous = pages[index - 1];
+
+    // 飛んでいるところにだけ省略記号を挟む。1つ飛びなら数字をそのまま出す。
+    return previous !== undefined && page - previous > 1
+      ? [null, page]
+      : [page];
+  });
+}
+
+function href(basePath: string, page: number): string {
+  return page === 1 ? basePath : `${basePath}/page/${page}`;
+}
+
+/** 記事一覧の頁送り。無限スクロールはクローラーが辿れないので、
+    実際のリンクとしての導線をここで持つ。 */
+export default function Pager({
+  basePath,
+  current,
+  total,
+}: PagerProps): null | React.JSX.Element {
+  if (total <= 1) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Pagination" className={styles.pager}>
+      {current > 1 ? (
+        <Link
+          className={styles.step}
+          href={href(basePath, current - 1)}
+          rel="prev"
+        >
+          ‹ Prev
+        </Link>
+      ) : (
+        <span className={styles.stepDisabled}>‹ Prev</span>
+      )}
+      <ul className={styles.list}>
+        {visiblePages(current, total).map((page, index) =>
+          page === null ? (
+            <li aria-hidden="true" className={styles.gap} key={`gap-${index}`}>
+              …
+            </li>
+          ) : (
+            <li key={page}>
+              {page === current ? (
+                <span aria-current="page" className={styles.currentPage}>
+                  {page}
+                </span>
+              ) : (
+                <Link className={styles.page} href={href(basePath, page)}>
+                  {page}
+                </Link>
+              )}
+            </li>
+          ),
+        )}
+      </ul>
+      {current < total ? (
+        <Link
+          className={styles.step}
+          href={href(basePath, current + 1)}
+          rel="next"
+        >
+          Next ›
+        </Link>
+      ) : (
+        <span className={styles.stepDisabled}>Next ›</span>
+      )}
+    </nav>
+  );
+}

--- a/src/app/[locale]/_components/Pager/style.module.css
+++ b/src/app/[locale]/_components/Pager/style.module.css
@@ -1,0 +1,59 @@
+/* 一覧の下に置く頁送り。額縁や記事カードと同じ破線の見た目に合わせる。 */
+.pager {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 720px;
+  padding: 24px 8px 8px;
+  width: 100%;
+}
+
+.list {
+  display: flex;
+  gap: 6px;
+  list-style: none;
+}
+
+.page,
+.currentPage,
+.step,
+.stepDisabled {
+  border: 1px dashed var(--color-line);
+  border-radius: 6px;
+  display: grid;
+  min-width: 2.4rem;
+  padding: 6px 10px;
+  place-items: center;
+  transition: color 150ms;
+}
+
+.page:hover,
+.step:hover {
+  color: var(--color-accent);
+}
+
+.currentPage {
+  background: var(--color-frame-band);
+  color: var(--color-accent);
+}
+
+.stepDisabled {
+  border-style: dotted;
+  opacity: 0.4;
+}
+
+/* 省略記号は枠を持たせず、数字の並びの隙間として見せる。 */
+.gap {
+  align-self: end;
+  opacity: 0.5;
+  padding: 6px 2px;
+}
+
+@media (width >= 980px) {
+  .pager {
+    gap: 16px;
+    padding: 32px 12px 8px;
+  }
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -5,6 +5,7 @@ import getArticles from "@/libs/getArticles";
 import getMetadata from "@/libs/getMetadata";
 import pageSize from "@/libs/pageSize";
 import ArticleList from "../_components/ArticleList";
+import Pager from "../_components/Pager";
 
 type PageProps = {
   params: Promise<{ locale: string }>;
@@ -31,6 +32,7 @@ export default async function Page({
 
   const articles = await getArticles(toLocale(locale));
   const firstPage = articles.slice(0, pageSize);
+  const total = Math.max(1, Math.ceil(articles.length / pageSize));
 
   return (
     <main>
@@ -44,6 +46,7 @@ export default async function Page({
         heading="BLOG"
         infinite={true}
       />
+      <Pager basePath="/blog" current={1} total={total} />
     </main>
   );
 }

--- a/src/app/[locale]/blog/page/[page]/page.tsx
+++ b/src/app/[locale]/blog/page/[page]/page.tsx
@@ -1,0 +1,85 @@
+import { type Metadata } from "next";
+import { setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import { routing, toLocale } from "@/i18n/routing";
+import getArticles from "@/libs/getArticles";
+import getMetadata from "@/libs/getMetadata";
+import pageSize from "@/libs/pageSize";
+import ArticleList from "../../../_components/ArticleList";
+import Pager from "../../../_components/Pager";
+
+type PageProps = {
+  params: Promise<{ locale: string; page: string }>;
+};
+
+function totalPages(count: number): number {
+  return Math.max(1, Math.ceil(count / pageSize));
+}
+
+/** 2ページ目以降だけを作る。1ページ目は /blog が持っているので、
+    ここで作ると同じ内容が2つの URL に出てしまう。 */
+export async function generateStaticParams(): Promise<
+  { locale: string; page: string }[]
+> {
+  const params = await Promise.all(
+    routing.locales.map(async (locale) => {
+      const articles = await getArticles(locale);
+
+      return Array.from(
+        { length: totalPages(articles.length) - 1 },
+        (_, index) => ({
+          locale,
+          page: String(index + 2),
+        }),
+      );
+    }),
+  );
+
+  return params.flat();
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale, page } = await params;
+
+  return getMetadata({
+    locale: toLocale(locale),
+    path: `/blog/page/${page}`,
+    subTitle: `BLOG (${page})`,
+  });
+}
+
+export default async function Page({
+  params,
+}: PageProps): Promise<React.JSX.Element> {
+  const { locale, page } = await params;
+
+  setRequestLocale(locale);
+
+  const articles = await getArticles(toLocale(locale));
+  const total = totalPages(articles.length);
+  const current = Number(page);
+
+  // 範囲外と数字でない頁は 404 にする。存在しない URL を薄い中身で返さない。
+  if (!Number.isSafeInteger(current) || current < 2 || current > total) {
+    notFound();
+  }
+
+  const items = articles.slice((current - 1) * pageSize, current * pageSize);
+
+  return (
+    <main>
+      <ArticleList
+        items={items.map(({ date, slug, text, title }) => ({
+          date,
+          href: `/blog/${slug}`,
+          text,
+          title,
+        }))}
+        heading="BLOG"
+      />
+      <Pager basePath="/blog" current={current} total={total} />
+    </main>
+  );
+}


### PR DESCRIPTION
## What

Search Console reports 823 pages as not indexed against 111 indexed. Sampling with the URL Inspection API shows the bulk of them are Japanese blog articles in the state "Discovered - currently not indexed", never crawled.

## Why

`/blog` renders only the newest 20 articles and loads the rest over `fetch` through infinite scroll. There is no pagination link anywhere, so **476 of the 496 Japanese articles have no inbound link at all**. The sitemap is their only route in, and Google has been declining to crawl them.

## How

- `src/app/[locale]/blog/page/[page]/page.tsx` — prerendered pages 2..N, one per locale
- `src/app/[locale]/_components/Pager/` — the pager. Keeps both ends and the current page's neighbours, folding the rest into an ellipsis so 25 pages still fit on one line
- `/blog` keeps infinite scroll and gains the pager below it

Page 1 stays at `/blog` and is not duplicated under `/blog/page/1`.

```
● /ja/blog/page/2 … /ja/blog/page/25    24 pages
● /en/blog/page/2                        1 page
sitemap: 554 → 579 URLs
```

## Trade-off

With the ellipsis pager, reaching page 13 from `/blog` takes 12 hops. Every page is in the sitemap, so discovery does not depend on that depth, but the link depth remains. Listing all 25 numbers would flatten it at the cost of horizontal space.

## Verified

`type-check`, `eslint`, `stylelint`, `prettier`, `vitest` (25 tests), `build` all pass. Pager links were read out of the prerendered HTML, not just assumed:

```
/ja/blog          → /ja/blog/page/2, /ja/blog/page/25
/ja/blog/page/2   → /ja/blog/page/3, /ja/blog/page/25
```